### PR TITLE
Prune dead links, fix Burst URL, add link-check CI

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,44 @@
+name: Links
+
+on:
+  push:
+    branches: [master]
+    paths: [README.md, lychee.toml, .github/workflows/links.yml]
+  pull_request:
+    paths: [README.md, lychee.toml, .github/workflows/links.yml]
+  schedule:
+    - cron: "0 6 * * 1" # every Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links in README
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config lychee.toml --no-progress README.md
+          fail: false # never hard-fail the step; we decide below per-event
+
+      # On pull requests, broken links should block the merge.
+      - name: Fail PR on broken links
+        if: ${{ github.event_name == 'pull_request' && steps.lychee.outputs.exit_code != 0 }}
+        run: |
+          echo "::error::lychee found broken links. See the job summary."
+          exit 1
+
+      # On the weekly schedule, file/refresh a tracking issue instead.
+      - name: Open issue on broken links (scheduled run)
+        if: ${{ github.event_name == 'schedule' && steps.lychee.outputs.exit_code != 0 }}
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link checker found broken links
+          content-filepath: ./lychee/out.md
+          labels: link-rot, automated

--- a/README.md
+++ b/README.md
@@ -9,19 +9,15 @@ alt="dust mite" width="100%" title="By Benjamin Combs via Unsplash">
 A curated list of amazingly awesome free (stock) photo resources for your projects. Inspired by all the other [awesome awesomeness](https://github.com/bayandin/awesome-awesomeness) out there.
 
 * [AllTheFreeStock](http://allthefreestock.com/) - CC0 images. Some of the video requires attribution
-* [burst.shopify.com](https://burst.shopify.com) - free photos for non-commercial and commercial use. No attribution required.
-* [fancycrave.com](http://fancycrave.com/) - royalty free high resolution images for your personal and commercial projects
 * [flickr.com](https://www.flickr.com/photos/internetarchivebookimages/) - internet archive book images, no known copyright restrictions
 * [foodiesfeed.com](http://foodiesfeed.com/) - food images, free of licences
 * [getrefe.tumblr.com](http://getrefe.tumblr.com/) - photos of people interacting with technology for personal or commercial projects
 * [gratisography.com](http://www.gratisography.com/) - all pictures are free of copyright restrictions
-* [imcreator.com](http://imcreator.com/free) - requires attribution
 * [isorepublic.com](http://isorepublic.com/) - high-quality, free photos for creatives.
 * [jaymantri.com](http://jaymantri.com/) - entirely free of copyrights. 7 new photos every thursday.
 * [kaboompics.com](http://kaboompics.com/)
 * [lifeofpix.com](http://www.lifeofpix.com/) - images for personal & commercial use. all images are donated to the public domain
 * [littlevisuals.co](http://littlevisuals.co/) - entirely free of copyrights. updated almost daily.
-* [lockandstockphotos.com](http://lockandstockphotos.com/) - requires attribution
 * [magdeleine.co](http://magdeleine.co/) - hand picked, most images are free of licences
 * [morguefile.com](http://www.morguefile.com/) - no attribution required
 * [moveast.me](http://moveast.me/) - a guy on a photographic journey. all images are CC0
@@ -32,11 +28,8 @@ A curated list of amazingly awesome free (stock) photo resources for your projec
 * [picography.co](http://picography.co/) - free of licences
 * [Pixabay](https://pixabay.com/) - photos, vector graphics, and illustrations - custom license limiting commercial use
 * [publicdomainarchive.com](http://publicdomainarchive.com/) - public domain images
-* [publicphoto.org](http://publicphoto.org/) - public domain photos
-* [raumrot.com](http://www.raumrot.com/)
-* [resplashed.com](http://www.resplashed.com/) - HD images for your web and design projects. CC0.
+* [Shopify (Burst)](https://www.shopify.com/stock-photos) - free photos for personal and commercial use. No attribution required.
 * [smart.servier.com](https://smart.servier.com/) - medical illustrations, free to share and adapt commercially, attribution required
-* [somersault1824.com](http://www.somersault1824.com/science-illustrations/) - scientific illustrations, free (pay-what-you-want) for non-commercial use, attribution required
 * [SpaceX](https://www.flickr.com/photos/spacexphotos) - high resolution Space-related media in the public domain
 * [splitshire.com](http://splitshire.com/) - delicious free stock photos for personal & commercial use
 * [startupstockphotos.com](http://startupstockphotos.com/) - startup related photos, free of licences

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,25 @@
+# Configuration for the lychee link checker (https://github.com/lycheeverse/lychee)
+
+# HTTP status codes treated as success.
+# 429 = rate-limited (the link exists, we were just throttled).
+accept = [200, 206, 429]
+
+# Retry/timeout tuning so transient hiccups don't fail the build.
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+
+# Look like a real browser; some hosts 403 the default agent.
+user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+
+# These hosts serve normally in a browser but return 401/403 to
+# automated/CI clients (Cloudflare / anti-bot challenges). Excluding
+# them avoids permanent false negatives. Re-check by hand occasionally.
+exclude = [
+  "kaboompics\\.com",
+  "(www\\.)?pexels\\.com",
+  "pixabay\\.com",
+  "stocksnap\\.io",
+  "(www\\.)?morguefile\\.com",
+  "unsplash\\.com",
+]


### PR DESCRIPTION
Validated all 37 resources currently listed in the README (followed redirects, inspected page titles, and distinguished genuine 404/503/parked pages from anti-bot 403 challenges).

## Removed — dead / parked / discontinued
| Site | Reason |
|---|---|
| `publicphoto.org` | Domain gone — redirects to `studyfy.com` SEO blog |
| `raumrot.com` | Domain gone — redirects to `howtostartanllc.org` affiliate page |
| `lockandstockphotos.com` | Parked "Coming Soon" placeholder |
| `resplashed.com` | 503 Cloudflare "Unknown Site" — origin gone |
| `somersault1824.com/science-illustrations` | 404 — illustration library discontinued (homepage is now a design agency) |

## Removed — no longer free (out of scope for a *free* images list)
| Site | Reason |
|---|---|
| `fancycrave.com` | Pivoted to premium / subscription |
| `imcreator.com/free` | Free gallery gone; now a website builder |

## Changed
- **burst.shopify.com → https://www.shopify.com/stock-photos** — Shopify retired the "Burst" brand; the photos are still free with no attribution required. Re-sorted to keep the list alphabetical.

## CI (closes #35)
- `lychee.toml` + `.github/workflows/links.yml` — checks README links on PRs (blocks merge on breakage) and weekly (opens a tracking issue).
- Known anti-bot hosts that 401/403 CI clients but work in browsers (`pexels`, `pixabay`, `unsplash`, `stocksnap`, `kaboompics`, `morguefile`) are excluded so CI isn't permanently red on false negatives.

The 6 excluded hosts and the rest of the list were all confirmed live in a browser-style request. List is down from 37 → 30 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)