### PR TITLE
add pexafy.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A curated list of amazingly awesome free (stock) photo resources for your projec
 * [morguefile.com](http://www.morguefile.com/) - no attribution required
 * [moveast.me](http://moveast.me/) - a guy on a photographic journey. all images are CC0
 * [nos.twnsnd.co](http://nos.twnsnd.co/) - vintage images, free of any copyright restrictions
+* [pexafy.com](https://pexafy.com) - semantic search across 9 free photo sites (unsplash, pexels, pixabay & more): plain-language queries or reverse image search. real photography, no AI-generated images. free API
 * [pexels.com](http://www.pexels.com/) - beautiful collection of photos, free of licenses
 * [photostockeditor.com](http://www.photostockeditor.com/) - free high-resolution images for personal and commercial use
 * [picjumbo.com](http://picjumbo.com/) - totally free photos for your commercial & personal works


### PR DESCRIPTION
Adds pexafy.com, placed alphabetically between nos.twnsnd.co and pexels.com.

It searches nine of the free photo sites already on this list (Unsplash, Pexels, Pixabay, Kaboompics, Burst, StockSnap, Picjumbo, Skitterphoto, NegativeSpace) from one place, matching on a plain-language description of the image rather than on tags. Reverse image search is available too, and each result carries its source license type.

On the no-AI rule: every photo is real photography coming from the sites above. Nothing is AI-generated — the AI is only in the search, not in the images.